### PR TITLE
Update keysize for self signed certificate to 2048

### DIFF
--- a/packages/tcp/src/TCPTransport.ts
+++ b/packages/tcp/src/TCPTransport.ts
@@ -217,5 +217,5 @@ export class TCPTransport extends AbstractTransport {
 }
 
 function generateSelfSignedCertificate(): { private: Buffer, cert: Buffer } {
-	return selfsigned.generate([], { days: 365 * 5 });
+	return selfsigned.generate([], { keySize: 2048, days: 365 * 5 });
 }


### PR DESCRIPTION
Fix for #13  SSL_CTX_use_certificate:ee key too small. Bumped up the keysize to 2048