### PR TITLE
Fix SynchronizedValues when setLocal is called multiple times

### DIFF
--- a/packages/core/test/SynchronizedValues.test.ts
+++ b/packages/core/test/SynchronizedValues.test.ts
@@ -26,6 +26,7 @@ describe('SynchronizedValues', () => {
 	});
 
 	afterEach(async () => {
+		await sleep(); // allow all pending promises to exit cleanly
 		for(let i = cleanups.length - 1; i >= 0; i--) {
 			await cleanups[i]();
 		}
@@ -94,7 +95,7 @@ describe('SynchronizedValues', () => {
 		expect(stateEventCount).toBe(2);
 	});
 
-	xit('Set, A <-> B, twice', async () => {
+	it('Set, A <-> B, twice', async () => {
 		testNetwork.bidirectional('a', 'b');
 
 		await testNetwork.consolidate();
@@ -276,7 +277,7 @@ describe('SynchronizedValues', () => {
 			expect(bState.get(aNode)).toBe('aValue');
 		});
 
-		xit('set and get twice', async () => {
+		it('set and get twice', async () => {
 			aState.setLocal('aValueInitial');
 			bState.setLocal('bValueInitial');
 			await sleep();


### PR DESCRIPTION
I noticed that `SynchronizedValues` only updated properly on the first time `setLocal` was called, and after that the values of other nodes weren't updated. Investigating the logs with the `DEBUG` environment variable showed the following lines:

```
2021-11-02T13:05:27.853Z ataraxia:foobar:state:synchronized-thing Received an update from 38Fi0LDHimAiMCjAURRPcj with version 0 but currently at 1 - patch will be skipped
```

On further investigation, it seemed apparent that `nodeState.knownLocalVersion` was not updated properly after sending patches. This PR introduces a new message type that's used to acknowledge the updated version. It also introduces additional tests for this functionality, as well as for some more basic `setLocal`/`get` flows.

I still think there are a couple of improvements that could be made:
- I'm not sure this handles all race conditions perfectly, for an instance if a node updates from version 0 to 1 and then from 1 to 2 on a quick succession, it's possible that the update from 1 to 2 gets seen first and this can cause issues.
- There's no error handling in case some message is not sent. Maybe `SynchronizedValues` should periodically do a full sync over the whole network?
- This is unrelated to the PR, but there's this part of the code
    ```
	private sendStatePatch(node: Node<Message>, lastVersion: number): void {
            ...
		const patch = this.generatePatch(this.localValue, this.localVersion);
    ```
    Since the second parameter of `generatePatch` is called `previousVersion`, shouldn't `lastVersion` be used here instead of `this.localVersion`? I didn't touch this part since I'm not using advanced batch logic and I'm not sure if this is the case.

Thanks for the awesome library, BTW!