### PR TITLE
fix(services): Fix onServiceUnavailable

### DIFF
--- a/packages/services/src/Services.ts
+++ b/packages/services/src/Services.ts
@@ -751,6 +751,7 @@ export class Services {
 			this.updateServiceReflect(existing, reflect);
 		} else {
 			// Register that the service is reachable through this node
+			data.services.set(id, reflect);
 			this.registerServiceReflect(reflect);
 		}
 


### PR DESCRIPTION
The event is not triggered if service registration happens after node is available