### PR TITLE
fix(core): Fix findAndGossip

### DIFF
--- a/packages/core/src/Gossiper.ts
+++ b/packages/core/src/Gossiper.ts
@@ -28,6 +28,9 @@ export class Gossiper<V extends object> {
 
 	private findAndGossip() {
 		const nodes = this.group.nodes;
+		if(nodes.length === 0) {
+			return;
+		}
 		const idx = Math.floor(Math.random() * nodes.length);
 
 		const node = nodes[idx];


### PR DESCRIPTION
The method didn't check if group nodes length was empty before picking a node for gossip.